### PR TITLE
Store CA cert in all namespaces

### DIFF
--- a/fixca/__main__.py
+++ b/fixca/__main__.py
@@ -31,13 +31,19 @@ def main() -> None:
     add_event_listener(EventType.SHUTDOWN, shutdown)
 
     CA.initialize(namespace=args.namespace, secret_name=args.secret, dummy_ca=args.dummy_ca)
+    CA.store_ca_certs()
 
-    common_name = "ca.fix"
+    common_name = "fixca"
     cert_key = gen_rsa_key()
     cert_csr = gen_csr(
         cert_key,
         common_name=common_name,
-        san_dns_names=[common_name],
+        san_dns_names=[
+            common_name,
+            f"{common_name}.{args.namespace}",
+            f"{common_name}.{args.namespace}.svc",
+            f"{common_name}.{args.namespace}.svc.cluster.local",
+        ],
     )
     cert_crt = CA.sign(cert_csr)
     with TemporaryDirectory() as tmpdir:

--- a/fixca/ca.py
+++ b/fixca/ca.py
@@ -20,7 +20,7 @@ from resotolib.x509 import (
     gen_ca_bundle_bytes,
 )
 from resotolib.jwt import encode_jwt, decode_jwt_from_headers
-from .k8s import get_secret, set_secret
+from .k8s import get_secret, set_secret, get_namespaces
 from .utils import str_to_bool
 
 
@@ -142,6 +142,16 @@ class CertificateAuthority:
             secret_name=secret_name,
             data=secret,
         )
+
+    @requires_initialized
+    def store_ca_certs(self, exclude_system: bool = True) -> None:
+        for namespace in get_namespaces(exclude_system=exclude_system):
+            log.debug(f"Storing CA cert in {namespace}/fix-ca-cert")
+            set_secret(
+                namespace=namespace,
+                secret_name="fix-ca-cert",
+                data={"ca.crt": cert_to_bytes(self.cert).decode("utf-8")},
+            )
 
 
 CA: CertificateAuthority = CertificateAuthority()

--- a/fixca/ca.py
+++ b/fixca/ca.py
@@ -145,6 +145,7 @@ class CertificateAuthority:
 
     @requires_initialized
     def store_ca_certs(self, exclude_system: bool = True) -> None:
+        assert self.cert is not None
         for namespace in get_namespaces(exclude_system=exclude_system):
             log.debug(f"Storing CA cert in {namespace}/fix-ca-cert")
             set_secret(


### PR DESCRIPTION
# Description

This PR:
- stores the CA cert in all namespaces upon startup
- updates the server cert's common and san dns names

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://fix.tt/code-of-conduct).
